### PR TITLE
Add the raw_parser option to pass XML directly to the exporter

### DIFF
--- a/lib/Catmandu/Store/Datahub.pm
+++ b/lib/Catmandu/Store/Datahub.pm
@@ -16,6 +16,7 @@ has client_id     => (is => 'ro', required => 1);
 has client_secret => (is => 'ro', required => 1);
 has username      => (is => 'ro', required => 1);
 has password      => (is => 'ro', required => 1);
+has raw_parser    => (is => 'ro', default => sub { return 0; });
 
 has client       => (is => 'lazy');
 has access_token => (
@@ -96,6 +97,10 @@ Datahub username.
 =item C<password>
 
 Datahub password.
+
+=item C<raw_parser>
+
+If the input was parsed by the raw XML parser (Catmandu::Importer::OAI::Parser::raw), set this to 1 to pass the XML directly to the exporter.
 
 =back
 

--- a/lib/Catmandu/Store/Datahub/API.pm
+++ b/lib/Catmandu/Store/Datahub/API.pm
@@ -6,6 +6,7 @@ use warnings;
 use Catmandu;
 use Moo;
 use JSON;
+use Encode qw(encode_utf8);
 
 use LWP::UserAgent;
 
@@ -90,7 +91,8 @@ sub add {
     my $token = $self->access_token;
     my $response;
 
-    $response = $self->client->post($url, Content_Type => 'application/lido+xml', Authorization => sprintf('Bearer %s', $token), Content => $data);
+    my $enc_data = encode_utf8($data);
+    $response = $self->client->post($url, Content_Type => 'application/lido+xml', Authorization => sprintf('Bearer %s', $token), Content => $enc_data);
 
     if ($response->is_success) {
         return $response->decoded_content;

--- a/lib/Catmandu/Store/Datahub/Bag.pm
+++ b/lib/Catmandu/Store/Datahub/Bag.pm
@@ -34,6 +34,9 @@ sub _build_api {
 around add => sub {
     my $orig = shift;
     my ($self, $data) = @_;
+    if ($self->store->raw_parser == 1) {
+      return $self->$orig($data);
+    }
     delete $data->{'_id'};
     return $self->$orig($data);
 };
@@ -70,7 +73,11 @@ sub get {
 # Create a new record
 sub add {
     my ($self, $data) = @_;
-    return $self->api->update($data->{'id'}, $data->{'_'});
+
+    if ($self->store->raw_parser == 1) {
+      return $self->api->add($data->{'_metadata'});
+    }
+    return $self->api->add($data->{'_'});
 }
 
 ##


### PR DESCRIPTION
Add the raw_parser option to pass XML parsed by AOI::Parser::raw directly to the exporter. See [this issue in Datahub-Factory](https://github.com/thedatahub/Datahub-Factory/issues/49).